### PR TITLE
Fix comments handling for SLE 12 GA

### DIFF
--- a/package/yast2-slp-server.changes
+++ b/package/yast2-slp-server.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 29 13:27:54 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix comments handling on slp.conf (bsc#878892)
+- 3.1.2
+
+-------------------------------------------------------------------
 Thu Nov 14 12:16:15 UTC 2013 - vmoravec@suse.com
 
 - fix incorrect firewall service bnc#825505

--- a/package/yast2-slp-server.spec
+++ b/package/yast2-slp-server.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-slp-server
-Version:        3.1.1
+Version:        3.1.2
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/scrconf/slp_conf.scr
+++ b/src/scrconf/slp_conf.scr
@@ -37,8 +37,7 @@
         // we need to exclude ; because of the second matching rule
         "params" : [
                 // Options with one value ('yes' / 'no')
-//                $[ "match" : [ "^[#;][ \t]*([^ \t]+)[ \t]+([^ \t]+)[ \t]+$", "%s %s" ]],
-                $[ "match" : [ "^[#;][ \t]*([^ \t\=]+)[ \t\=]?(.+)[ \t]*$", "; %s %s" ]],
+                $[ "match" : [ "^[#;][ \t]*([^ \t\=]+)[ \t\=]+[ ]*(.+)[ \t]*$", ";%s = %s" ]],
                 // Options with more possible values
                 $[ "match" : [ "^[ \t]*([^ \t\=]+)[ \t\=]+[ ]*(.+)[ \t]*$", "%s = %s" ]],
         ],


### PR DESCRIPTION
* Fixes bsc#878892.
* Tested manually.
* The same fix was submitted for SLE11 (https://github.com/yast/yast-slp-server/pull/7).